### PR TITLE
Fix droplet reconciler issue

### DIFF
--- a/apis/compute/v1alpha1/droplet_types.go
+++ b/apis/compute/v1alpha1/droplet_types.go
@@ -54,32 +54,32 @@ type DropletParameters struct {
 	// that you wish to embed in the Droplet's root account upon creation.
 	// +optional
 	// +immutable
-	SSHKeys []string `json:"ssh_keys"`
+	SSHKeys []string `json:"ssh_keys,omitempty"`
 
 	// Backups: A boolean indicating whether automated backups should be enabled
 	// for the Droplet. Automated backups can only be enabled when the Droplet is
 	// created.
 	// +optional
 	// +immutable
-	Backups *bool `json:"backups"`
+	Backups *bool `json:"backups,omitempty"`
 
 	// IPv6: A boolean indicating whether IPv6 is enabled on the Droplet.
 	// +optional
 	// +immutable
-	IPv6 *bool `json:"ipv6"`
+	IPv6 *bool `json:"ipv6,omitempty"`
 
 	// PrivateNetworking: This parameter has been deprecated. Use 'vpc_uuid'
 	// instead to specify a VPC network for the Droplet. If no `vpc_uuid` is
 	// provided, the Droplet will be placed in the default VPC.
 	// +optional
 	// +immutable
-	PrivateNetworking *bool `json:"private_networking"`
+	PrivateNetworking *bool `json:"private_networking,omitempty"`
 
 	// Monitoring: A boolean indicating whether to install the DigitalOcean
 	// agent for monitoring.
 	// +optional
 	// +immutable
-	Monitoring *bool `json:"monitoring"`
+	Monitoring *bool `json:"monitoring,omitempty"`
 
 	// Volumes: A flat array including the unique string identifier for each block
 	// storage volume to be attached to the Droplet. At the moment a volume can only
@@ -92,7 +92,7 @@ type DropletParameters struct {
 	// is created. Tag names can either be existing or new tags.
 	// +optional
 	// +immutable
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitempty"`
 
 	// VPCUUID: A string specifying the UUID of the VPC to which the Droplet
 	// will be assigned. If excluded, beginning on April 7th, 2020, the Droplet

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/crossplane-contrib/provider-digitalocean
 go 1.13
 
 require (
-	github.com/crossplane/crossplane-runtime v0.11.1-0.20201120062856-57ef784bfe43
-	github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb
+	github.com/crossplane/crossplane-runtime v0.12.0
+	github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d
 	github.com/digitalocean/godo v1.54.0
 	github.com/google/go-cmp v0.5.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -63,10 +63,10 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/crossplane/crossplane-runtime v0.11.1-0.20201120062856-57ef784bfe43 h1:eos1bgDVzi81wPwOVgOpWmEl+dtZ45y1PLMGjPZ4Bto=
-github.com/crossplane/crossplane-runtime v0.11.1-0.20201120062856-57ef784bfe43/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
-github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb h1:j09j/Gk1qH64HUtf/fcTjMAxLxUdOuQXySWu46WTVTU=
-github.com/crossplane/crossplane-tools v0.0.0-20201007233256-88b291e145bb/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
+github.com/crossplane/crossplane-runtime v0.12.0 h1:GB1Pq5vVBNStPrfiEJNat56gHCQiuliidgr7pNs/FQA=
+github.com/crossplane/crossplane-runtime v0.12.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
+github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d h1:QiCkTnlBf7OuQF3SJF3yGqS5SQuPOFPrs0pIRAsY7QY=
+github.com/crossplane/crossplane-tools v0.0.0-20201201125637-9ddc70edfd0d/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/clients/compute/droplet.go
+++ b/pkg/clients/compute/droplet.go
@@ -17,6 +17,7 @@ limitations under the License.
 package compute
 
 import (
+	"net/http"
 	"strconv"
 
 	"github.com/digitalocean/godo"
@@ -81,4 +82,17 @@ func LateInitializeSpec(p *v1alpha1.DropletParameters, observed godo.Droplet) {
 	p.Volumes = do.LateInitializeStringSlice(p.Volumes, observed.VolumeIDs)
 	p.Tags = do.LateInitializeStringSlice(p.Tags, observed.Tags)
 	p.VPCUUID = do.LateInitializeString(p.VPCUUID, observed.VPCUUID)
+}
+
+// IgnoreNotFound checks for response of DigitalOcean GET API call
+// and the content of returned error to ignore it if the response
+// is a '404 not found' error otherwise bubble up the error.
+func IgnoreNotFound(err error, response *godo.Response) error {
+	if err != nil && err.Error() == "dropletID is invalid because cannot be less than 1" {
+		return nil
+	}
+	if response != nil && response.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This PR fixes droplet reconciling loop issues, i.e. adding missing `omitempty` json tag to optional parameters. But the most notable change is adding a 1 second sleep in after `Create` was done in the following scenario:

1. create a `Droplet`
2. `Observe()` starts and sees the resource doesn't exist
3. `Create()` starts and eventually sets `Status.AtProvider.ID`
4. process return to `Observe()` but `Status.AtProvider.ID` is still empty and retriggers API to create droplet again

Edit: The original approach was dropped in favor of using `crossplane.io/external-name` annotation in `Observe()` and `Create()`.

To see original PR and discussion please check https://github.com/khos2ow/provider-digitalocean-deprecated/pull/6.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Applying [`examples/compute/droplet.yaml`](https://github.com/crossplane-contrib/provider-digitalocean/blob/86d9567cc58bb50f9e994f4aa8be8dd98c873460/examples/compute/droplet.yaml) and making sure there's only one droplet being created on DigitalOcean.

[contribution process]: https://git.io/fj2m9
