### PR TITLE
Fix host-arch variable.

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -138,6 +138,10 @@ eval $(make --no-print-directory -C ${projectdir} build.vars)
 # ------------------------------
 
 HOSTARCH="${HOSTARCH:-amd64}"
+if [ $HOSTARCH = "x86_64" ]; then
+    HOSTARCH=amd64
+fi
+
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
 CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${HOSTARCH}"
 


### PR DESCRIPTION
The variable `HOSTARCH` in the integration-tests.sh file is showing as x86_64 which is not a supported arch. I changed it to work like most all other make files and if `x86_64` is found then it will default it to `amd64`.