### PR TITLE
Switch to using buildx and imagelight.mk for multi-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,20 +80,6 @@ crds.clean:
 
 generate: crds.clean
 
-# Ensure a PR is ready for review.
-reviewable: generate lint
-	@go mod tidy
-
-# Ensure branch is clean.
-check-diff: reviewable
-	@$(INFO) checking that branch is clean
-	@if [ ! -z "$$(git status --porcelain)" ]; then \
-		$(WARN) Git status failure see below output; \
-		git status; \
-		$(FAIL); \
-	fi
-	@$(OK) branch is clean
-
 manifests:
 	@$(WARN) Deprecated. Please run make generate instead.
 

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Images
 
-DOCKER_REGISTRY = crossplane
+REGISTRY_ORGS = docker.io/crossplane
 IMAGES = provider-digitalocean provider-digitalocean-controller
--include build/makelib/image.mk
+-include build/makelib/imagelight.mk
 
 # ====================================================================================
 # Targets

--- a/cluster/images/provider-digitalocean-controller/Dockerfile
+++ b/cluster/images/provider-digitalocean-controller/Dockerfile
@@ -1,11 +1,10 @@
-FROM BASEIMAGE
-RUN apk --no-cache add ca-certificates bash
+FROM gcr.io/distroless/static@sha256:d2b0ec3141031720cf5eedef3493b8e129bc91935a43b50562fbe5429878d96b
 
-ARG ARCH
-ARG TINI_VERSION
+ARG TARGETOS
+ARG TARGETARCH
 
-ADD provider /usr/local/bin/crossplane-digitalocean-provider
+ADD bin/$TARGETOS\_$TARGETARCH/provider /usr/local/bin/crossplane-digitalocean-provider
 
 EXPOSE 8080
-USER 1001
+USER 65532
 ENTRYPOINT ["crossplane-digitalocean-provider"]

--- a/cluster/images/provider-digitalocean-controller/Makefile
+++ b/cluster/images/provider-digitalocean-controller/Makefile
@@ -1,25 +1,35 @@
 # ====================================================================================
 # Setup Project
 
-PLATFORMS := linux_amd64 linux_arm64
 include ../../../build/makelib/common.mk
 
 # ====================================================================================
 #  Options
-IMAGE = $(BUILD_REGISTRY)/provider-digitalocean-controller-$(ARCH)
-include ../../../build/makelib/image.mk
+
+include ../../../build/makelib/imagelight.mk
 
 # ====================================================================================
 # Targets
 
 img.build:
 	@$(INFO) docker build $(IMAGE)
+	@$(MAKE) BUILD_ARGS="--load" img.build.shared
+	@$(OK) docker build $(IMAGE)
+
+img.publish:
+	@$(INFO) docker publish $(IMAGE)
+	@$(MAKE) BUILD_ARGS="--push" img.build.shared
+	@$(OK) docker publish $(IMAGE)
+
+img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/provider $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
-	@docker build $(BUILD_ARGS) \
-		--build-arg ARCH=$(ARCH) \
-		--build-arg TINI_VERSION=$(TINI_VERSION) \
+	@cp -r $(OUTPUT_DIR)/bin/ $(IMAGE_TEMP_DIR)/bin || $(FAIL)
+	@docker buildx build $(BUILD_ARGS) \
+		--platform $(IMAGE_PLATFORMS) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
-	@$(OK) docker build $(IMAGE)
+
+img.promote:
+	@$(INFO) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
+	@docker buildx imagetools create -t $(TO_IMAGE) $(FROM_IMAGE)
+	@$(OK) docker promote $(FROM_IMAGE) to $(TO_IMAGE)

--- a/cluster/images/provider-digitalocean/Dockerfile
+++ b/cluster/images/provider-digitalocean/Dockerfile
@@ -1,3 +1,3 @@
-FROM BASEIMAGE
+FROM scratch
 
 COPY package.yaml .

--- a/cluster/images/provider-digitalocean/Makefile
+++ b/cluster/images/provider-digitalocean/Makefile
@@ -1,28 +1,37 @@
 # ====================================================================================
 # Setup Project
 
-PLATFORMS := linux_amd64 linux_arm64
 include ../../../build/makelib/common.mk
 
 # ====================================================================================
 #  Options
-IMAGE = $(BUILD_REGISTRY)/provider-digitalocean-$(ARCH)
-OSBASEIMAGE = scratch
-include ../../../build/makelib/image.mk
+
+include ../../../build/makelib/imagelight.mk
 
 # ====================================================================================
 # Targets
 
 img.build:
 	@$(INFO) docker build $(IMAGE)
+	@$(MAKE) BUILD_ARGS="--load" img.build.shared
+	@$(OK) docker build $(IMAGE)
+
+img.publish:
+	@$(INFO) docker publish $(IMAGE)
+	@$(MAKE) BUILD_ARGS="--push" img.build.shared
+	@$(OK) docker publish $(IMAGE)
+
+img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|VERSION|$(VERSION)|g' package/crossplane.yaml || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
-	@docker build $(BUILD_ARGS) \
-		--build-arg ARCH=$(ARCH) \
-		--build-arg TINI_VERSION=$(TINI_VERSION) \
+	@docker buildx build $(BUILD_ARGS) \
+		--platform $(IMAGE_PLATFORMS) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
-	@$(OK) docker build $(IMAGE)
+
+img.promote:
+	@$(INFO) docker promote $(FROM_IMAGE) to $(TO_IMAGE)
+	@docker buildx imagetools create -t $(TO_IMAGE) $(FROM_IMAGE)
+	@$(OK) docker promote $(FROM_IMAGE) to $(TO_IMAGE)

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -46,7 +46,7 @@ CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${SAFEHOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
 # tag as latest version to load into kind cluster
-PACKAGE_CONTROLLER_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}-controller:${VERSION}"
+PACKAGE_CONTROLLER_IMAGE="${PROJECT_NAME}/${PROJECT_NAME}-controller:${VERSION}"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Switches to using `imagelight.mk` and `buildx` so we can avoid publishing images to multiple repos before constructing a multi-arch image.

See https://github.com/crossplane/crossplane/pull/2718 for more information.

Repos have also been set up on Dockerhub:
- https://hub.docker.com/repository/docker/crossplane/provider-digitalocean
- https://hub.docker.com/repository/docker/crossplane/provider-digitalocean-controller

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make build.all`

[contribution process]: https://git.io/fj2m9
