### PR TITLE
Add the creation of connection details for a database cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ run: go.build
 
 dev: dev-kind dev-provider
 
-dev-kind: $(KIND) $(KUBECTL)
+dev-kind: $(KIND) $(KUBECTL) $(HELM3)
 	@$(INFO) Creating kind cluster
 	@$(KIND) create cluster --name=provider-digitalocean-dev
 	@$(KUBECTL) cluster-info --context kind-provider-digitalocean-dev


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The connection details for database clusters were not being published on creation.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #33 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I booted up a kind cluster, and installed Crossplane and then ran the provider. I then applied a Database Cluster resource with the `writeConnectionSecretToRef` specified and upon creation the secret was created.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
