### PR TITLE
Ability to pass user data to Droplets

### DIFF
--- a/apis/compute/v1alpha1/droplet_types.go
+++ b/apis/compute/v1alpha1/droplet_types.go
@@ -81,6 +81,11 @@ type DropletParameters struct {
 	// +immutable
 	Monitoring *bool `json:"monitoring,omitempty"`
 
+	// UserData: A string used to pass user data to the DigitalOcean Droplet.
+	// +optional
+	// +immutable
+	UserData *string `json:"userData,omitempty"`
+
 	// Volumes: A flat array including the unique string identifier for each block
 	// storage volume to be attached to the Droplet. At the moment a volume can only
 	// be attached to a single Droplet.

--- a/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -127,6 +127,11 @@ func (in *DropletParameters) DeepCopyInto(out *DropletParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UserData != nil {
+		in, out := &in.UserData, &out.UserData
+		*out = new(string)
+		**out = **in
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]string, len(*in))

--- a/examples/compute/droplet-user-data.yaml
+++ b/examples/compute/droplet-user-data.yaml
@@ -1,0 +1,18 @@
+apiVersion: compute.do.crossplane.io/v1alpha1
+kind: Droplet
+metadata:
+  name: user-data-example
+spec:
+  forProvider:
+    region: nyc1
+    size: s-1vcpu-1gb
+    image: ubuntu-20-04-x64
+    userData: |
+      #!/bin/bash
+      apt-get -y update
+      apt-get -y install nginx
+      export HOSTNAME=$(curl -s http://169.254.169.254/metadata/v1/hostname)
+      export PUBLIC_IPV4=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+      echo Droplet: $HOSTNAME, IP Address: $PUBLIC_IPV4 > /var/www/html/index.html
+  providerConfigRef:
+    name: example

--- a/package/crds/compute.do.crossplane.io_droplets.yaml
+++ b/package/crds/compute.do.crossplane.io_droplets.yaml
@@ -107,6 +107,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  userData:
+                    description: 'UserData: A string used to pass user data to the
+                      DigitalOcean Droplet.'
+                    type: string
                   volumes:
                     description: 'Volumes: A flat array including the unique string
                       identifier for each block storage volume to be attached to the

--- a/pkg/clients/compute/droplet.go
+++ b/pkg/clients/compute/droplet.go
@@ -36,6 +36,7 @@ func GenerateDroplet(name string, in v1alpha1.DropletParameters, create *godo.Dr
 	create.IPv6 = do.BoolValue(in.IPv6)
 	create.PrivateNetworking = do.BoolValue(in.PrivateNetworking)
 	create.Monitoring = do.BoolValue(in.Monitoring)
+	create.UserData = do.StringValue(in.UserData)
 	create.Volumes = generateVolumes(in.Volumes)
 	create.Tags = in.Tags
 	create.VPCUUID = do.StringValue(in.VPCUUID)


### PR DESCRIPTION
### Description of your changes

This PR adds the ability to pass user data at droplet creation time. Additional example is provided as well, based on the [official guide](https://docs.digitalocean.com/products/droplets/how-to/provide-user-data/).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran locally using a kind cluster.

