### PR TITLE
Droplet resource additional printer columns

### DIFF
--- a/apis/compute/v1alpha1/droplet_types.go
+++ b/apis/compute/v1alpha1/droplet_types.go
@@ -123,6 +123,18 @@ type DropletObservation struct {
 	// ID for the resource. This identifier is defined by the server.
 	ID int `json:"id,omitempty"`
 
+	// Private IPv4 address of the resource.
+	PrivateIPv4 string `json:"privateIPv4,omitempty"`
+
+	// Public IPv4 address of the resource.
+	PublicIPv4 string `json:"publicIPv4,omitempty"`
+
+	// Resource region slug.
+	Region string `json:"region,omitempty"`
+
+	// Resource size slug.
+	Size string `json:"size,omitempty"`
+
 	// A Status string indicating the state of the Droplet instance.
 	//
 	// Possible values:
@@ -148,7 +160,11 @@ type DropletStatus struct {
 // +kubebuilder:object:root=true
 
 // A Droplet is a managed resource that represents a DigitalOcean Droplet.
+// +kubebuilder:printcolumn:name="PRIVATE IPv4",type="string",JSONPath=".status.atProvider.privateIPv4"
+// +kubebuilder:printcolumn:name="PUBLIC IPv4",type="string",JSONPath=".status.atProvider.publicIPv4"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="REGION",type="string",JSONPath=".status.atProvider.region"
+// +kubebuilder:printcolumn:name="SIZE",type="string",JSONPath=".status.atProvider.size"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,do}

--- a/package/crds/compute.do.crossplane.io_droplets.yaml
+++ b/package/crds/compute.do.crossplane.io_droplets.yaml
@@ -21,8 +21,20 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.atProvider.privateIPv4
+      name: PRIVATE IPv4
+      type: string
+    - jsonPath: .status.atProvider.publicIPv4
+      name: PUBLIC IPv4
+      type: string
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: READY
+      type: string
+    - jsonPath: .status.atProvider.region
+      name: REGION
+      type: string
+    - jsonPath: .status.atProvider.size
+      name: SIZE
       type: string
     - jsonPath: .status.conditions[?(@.type=='Synced')].status
       name: SYNCED
@@ -195,6 +207,18 @@ spec:
                     description: ID for the resource. This identifier is defined by
                       the server.
                     type: integer
+                  privateIPv4:
+                    description: Private IPv4 address of the resource.
+                    type: string
+                  publicIPv4:
+                    description: Public IPv4 address of the resource.
+                    type: string
+                  region:
+                    description: Resource region slug.
+                    type: string
+                  size:
+                    description: Resource size slug.
+                    type: string
                   status:
                     description: "A Status string indicating the state of the Droplet
                       instance. \n Possible values:   \"new\"   \"active\"   \"off\"

--- a/pkg/controller/compute/droplet.go
+++ b/pkg/controller/compute/droplet.go
@@ -100,10 +100,16 @@ func (c *dropletExternal) Observe(ctx context.Context, mg resource.Managed) (man
 
 	currentSpec := cr.Spec.ForProvider.DeepCopy()
 	docompute.LateInitializeSpec(&cr.Spec.ForProvider, *observed)
+	observedPrivateIPv4, _ := observed.PrivateIPv4()
+	observedPublicIPv4, _ := observed.PublicIPv4()
 
 	cr.Status.AtProvider = v1alpha1.DropletObservation{
 		CreationTimestamp: observed.Created,
 		ID:                observed.ID,
+		PrivateIPv4:       observedPrivateIPv4,
+		PublicIPv4:        observedPublicIPv4,
+		Region:            observed.Region.Slug,
+		Size:              observed.SizeSlug,
 		Status:            observed.Status,
 	}
 	if err := c.kube.Status().Update(ctx, cr); err != nil {


### PR DESCRIPTION
Signed-off-by: Cristian Marius Tiutiu <v-ctiutiu@digitalocean.com>

### Description of your changes

This PR adds the ability to print additional columns for droplet resources. It helps visually to have droplet metadata displayed whenever you issue `kubectl get droplet` commands. On the other hand, it is useful when doing automations (via scripting), because you can fetch droplet information via the CLI.

Examples:
1. Fetch droplet resources with additional details:

    ```shell
    $ kubectl get droplets

    NAME          PRIVATE IPV4   PUBLIC IPV4      READY   REGION   SIZE          SYNCED
    nat-gw-nyc1   10.116.0.4     142.93.205.215   True    nyc1     s-1vcpu-1gb   True
    ```

2. Extract various fields using `kubectl`:

  - Droplet **private IP**:
    ```shell
    $ kubectl get droplet nat-gw-nyc1 -o jsonpath="{.status.atProvider.privateIPv4}"

    # Outputs - 10.116.0.4
    ```

  - Droplet **public IP**:
    ```shell
    $ kubectl get droplet nat-gw-nyc1 -o jsonpath="{.status.atProvider.publicIPv4}"

    # Outputs - 142.93.205.215
    ```

  - Droplet **region slug**:
    ```shell
    $ kubectl get droplet nat-gw-nyc1 -o jsonpath="{.status.atProvider.region}"

    # Outputs - nyc1
    ```

  - Droplet **size slug**:
    ```shell
    $ kubectl get droplet nat-gw-nyc1 -o jsonpath="{.status.atProvider.size}"

    # Outputs - s-1vcpu-1gb 
    ```
I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran locally using a kind cluster.