### PR TITLE
Allow adopting of exitsting droplets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tilt-settings.json
 tild.d/
 tilt_modules/
 cluster/local/provider.Tiltfile
+
+.env
+/test-files

--- a/apis/compute/v1alpha1/droplet_types.go
+++ b/apis/compute/v1alpha1/droplet_types.go
@@ -36,74 +36,62 @@ const (
 type DropletParameters struct {
 	// Region: The unique slug identifier for the region that you wish to
 	// deploy in.
-	// +immutable
 	Region string `json:"region"`
 
 	// Size: The unique slug identifier for the size that you wish to select
 	// for this Droplet.
-	// +immutable
 	Size string `json:"size"`
 
 	// Image: The image ID of a public or private image, or the unique slug
 	// identifier for a public image. This image will be the base image for
 	// your Droplet.
-	// +immutable
 	Image string `json:"image"`
 
 	// SSHKeys: An array containing the IDs or fingerprints of the SSH keys
 	// that you wish to embed in the Droplet's root account upon creation.
 	// +optional
-	// +immutable
 	SSHKeys []string `json:"sshKeys,omitempty"`
 
 	// Backups: A boolean indicating whether automated backups should be enabled
 	// for the Droplet. Automated backups can only be enabled when the Droplet is
 	// created.
 	// +optional
-	// +immutable
 	Backups *bool `json:"backups,omitempty"`
 
 	// IPv6: A boolean indicating whether IPv6 is enabled on the Droplet.
 	// +optional
-	// +immutable
 	IPv6 *bool `json:"ipv6,omitempty"`
 
 	// PrivateNetworking: This parameter has been deprecated. Use 'vpc_uuid'
 	// instead to specify a VPC network for the Droplet. If no `vpc_uuid` is
 	// provided, the Droplet will be placed in the default VPC.
 	// +optional
-	// +immutable
 	PrivateNetworking *bool `json:"privateNetworking,omitempty"`
 
 	// Monitoring: A boolean indicating whether to install the DigitalOcean
 	// agent for monitoring.
 	// +optional
-	// +immutable
 	Monitoring *bool `json:"monitoring,omitempty"`
 
 	// UserData: A string used to pass user data to the DigitalOcean Droplet.
 	// +optional
-	// +immutable
 	UserData *string `json:"userData,omitempty"`
 
 	// Volumes: A flat array including the unique string identifier for each block
 	// storage volume to be attached to the Droplet. At the moment a volume can only
 	// be attached to a single Droplet.
 	// +optional
-	// +immutable
 	Volumes []string `json:"volumes,omitempty"`
 
 	// Tags: A flat array of tag names as strings to apply to the Droplet after it
 	// is created. Tag names can either be existing or new tags.
 	// +optional
-	// +immutable
 	Tags []string `json:"tags,omitempty"`
 
 	// VPCUUID: A string specifying the UUID of the VPC to which the Droplet
 	// will be assigned. If excluded, beginning on April 7th, 2020, the Droplet
 	// will be assigned to your account's default VPC for the region.
 	// +optional
-	// +immutable
 	VPCUUID *string `json:"vpcUuid,omitempty"`
 
 	// WithDropletAgent: A boolean indicating whether to install the DigitalOcean
@@ -111,7 +99,6 @@ type DropletParameters struct {
 	// To prevent it from being installed, set to false.
 	// To make installation errors fatal, explicitly set it to true.
 	// +optional
-	// +immutable
 	WithDropletAgent *bool `json:"withDropletAgent,omitempty"`
 }
 
@@ -148,7 +135,9 @@ type DropletObservation struct {
 // A DropletSpec defines the desired state of a Droplet.
 type DropletSpec struct {
 	xpv1.ResourceSpec `json:",inline"`
-	ForProvider       DropletParameters `json:"forProvider"`
+
+	// +optional
+	ForProvider DropletParameters `json:"forProvider"`
 }
 
 // A DropletStatus represents the observed state of a Droplet.

--- a/examples/compute/droplet.yaml
+++ b/examples/compute/droplet.yaml
@@ -2,8 +2,6 @@ apiVersion: compute.do.crossplane.io/v1alpha1
 kind: Droplet
 metadata:
   name: example
-  annotations:
-    crossplane.io/external-name: crossplane-droplet
 spec:
   forProvider:
     region: nyc1

--- a/examples/compute/existing-droplet.yaml
+++ b/examples/compute/existing-droplet.yaml
@@ -1,0 +1,12 @@
+apiVersion: compute.do.crossplane.io/v1alpha1
+kind: Droplet
+metadata:
+  annotations:
+    crossplane.io/external-name: "1234567"
+  name: example
+spec:
+  # If you don't want to delete the existing droplet 
+  # when the managed resource is deleted
+  deletionPolicy: Orphan
+  providerConfigRef:
+    name: default

--- a/package/crds/compute.do.crossplane.io_droplets.yaml
+++ b/package/crds/compute.do.crossplane.io_droplets.yaml
@@ -190,8 +190,6 @@ spec:
                 - name
                 - namespace
                 type: object
-            required:
-            - forProvider
             type: object
           status:
             description: A DropletStatus represents the observed state of a Droplet.

--- a/pkg/clients/compute/droplet.go
+++ b/pkg/clients/compute/droplet.go
@@ -80,6 +80,15 @@ func generateVolumes(param []string) []godo.DropletCreateVolume {
 // supplied DropletParameters that are set (i.e. non-zero) on the supplied
 // Droplet.
 func LateInitializeSpec(p *v1alpha1.DropletParameters, observed godo.Droplet) {
+
+	if p == nil {
+		return
+	}
+
+	p.Region = observed.Region.Slug
+	p.Size = observed.SizeSlug
+	p.Image = observed.Image.Slug
+
 	p.Volumes = do.LateInitializeStringSlice(p.Volumes, observed.VolumeIDs)
 	p.Tags = do.LateInitializeStringSlice(p.Tags, observed.Tags)
 	p.VPCUUID = do.LateInitializeString(p.VPCUUID, observed.VPCUUID)

--- a/pkg/clients/digitalocean.go
+++ b/pkg/clients/digitalocean.go
@@ -19,6 +19,7 @@ package clients
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/digitalocean/godo"
@@ -164,4 +165,15 @@ func IgnoreNotFound(err error, response *godo.Response) error {
 		return nil
 	}
 	return err
+}
+
+// GetResourceID gets the resource ID in int form for a given string.
+func GetResourceID(id string) int {
+	result, err := strconv.Atoi(id)
+
+	if err != nil {
+		return -1
+	}
+
+	return result
 }


### PR DESCRIPTION
### Description of your changes

Starts #66 

This will allow the adopting of existing droplets into Crossplane so that users can bring their existing infra. I've also fixed the example and included an extra example for adopting an existing droplet.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran local cluster with kind, and adopted an existing resource. Also verified that it is not deleted when set to orphaned. Also verified that if an invalid ID is given it will error out and not continue.

[contribution process]: https://git.io/fj2m9
